### PR TITLE
Allow memento link to be opened in new window

### DIFF
--- a/mink-plugin/css/minkui.css
+++ b/mink-plugin/css/minkui.css
@@ -27,7 +27,7 @@ h1 {font-size: 14px; font-family: 'Futura', 'Century Gothic', AppleGothic, sans-
 
 #drilldownBox {border: 1px solid #999; z-index: 3;  padding: 2px; z-index: 1; font-family: Arial, sans-serif; background-color: white; margin-left: 210px; top: 91px; position: absolute; border-top: 5px solid #aaf; border-bottom: 5px solid #aaf;}
 #drilldownBox ul {list-style-type: none; width: 100px; float: left;  padding: 0; background-color: white; max-height: 500px; overflow-x: hidden; overflow-y: auto; margin-top: 0; margin-bottom: 0;}
-#drilldownBox ul li {list-style-type: none; padding: 0; margin: 0; width: 90px;}
+#drilldownBox ul li, #drilldownBox ul li a {list-style-type: none; padding: 0; margin: 0; width: 90px; text-decoration: none; color: inherit;}
 #drilldownBox ul li:hover {background-color: #ddddff; cursor: pointer;}
 #drilldownBox ul li.selectedOption {background-color: #ddddff; border-right:3px solid #aaf;}
 #drilldownBox ul li span.memCount {float: right;  font-family: Monaco, Courier, sans-serif; padding: 0px 3px; margin-right: 5px; border-radius: 2px; line-height: 10px;}

--- a/mink-plugin/js/displayMinkUI.js
+++ b/mink-plugin/js/displayMinkUI.js
@@ -483,13 +483,16 @@ function buildDrilldownTime (year, month, date) {
     li.setAttribute('data-day', date)
     li.setAttribute('data-month', month)
     li.setAttribute('data-year', year)
-    li.appendChild(document.createTextNode(times[timeIndex].time))
 
-    li.onclick = function (event) {
-      $(this).siblings().removeClass('selectedOption')
-      $(this).addClass('selectedOption')
-      window.location = times[timeIndex].uri
+    let a = document.createElement('a')
+    a.appendChild(document.createTextNode(times[timeIndex].time))
+    a.setAttribute('href', times[timeIndex].uri)
+
+    a.onclick = function (event) {
+      $(this).parent().siblings().removeClass('selectedOption')
+      $(this).parent().addClass('selectedOption')
     }
+    li.appendChild(a)
 
     timeUL.appendChild(li)
   }


### PR DESCRIPTION
Memento link in the Mink UI was an LI with JS tied to onclick,
which prevented typical link interaction, like opening the link
in a new window. This PR converts the LI to contain an
enclosing <a> and allows operations like in #268 to be performed.

Closes #268