### PR TITLE
Check valid URIs in a TimeMap without resorting to regex.

### DIFF
--- a/mink-plugin/timemap.js
+++ b/mink-plugin/timemap.js
@@ -1,4 +1,15 @@
 /* global debug */
+const debug = false
+
+function isValidURL (string) {
+  try {
+    new URL(string)
+  } catch (_) {
+    return false
+  }
+
+  return true
+}
 
 function Timemap (fromString) {
   if (debug) { console.log('In timemap.js') }
@@ -50,7 +61,7 @@ function Timemap (fromString) {
     const partsOfEntry = linkHeaderEntries[lhe].split(';')
 
     for (let partOfEntry = 0; partOfEntry < partsOfEntry.length; partOfEntry++) {
-      if (partsOfEntry[partOfEntry].match(murlregex)) {
+      if (isValidURL(partsOfEntry[partOfEntry].slice(1, -1))) {
         url = partsOfEntry[partOfEntry]
       }
 

--- a/mink-plugin/timemap.js
+++ b/mink-plugin/timemap.js
@@ -37,9 +37,6 @@ function Timemap (fromString) {
 
   const linkHeaderEntries = this.str.split(',')
 
-  const mementoUrlExpression = /<[-a-zA-Z0-9@:%_+.~#?&//=]{2,256}\.[a-z]{2,4}\b(\/[-a-zA-Z0-9@:%_+.~#?&//=]*)?>/gi
-  const murlregex = new RegExp(mementoUrlExpression) // Regex to get a memento URI
-
   const mementoRelTimegateExpression = /rel=.*timegate.*/gi
   const mtimegateregex = new RegExp(mementoRelTimegateExpression) // Regex to get timegate
 


### PR DESCRIPTION
A previous attempt per #289 caused URI-Rs with a port number to
fail the regex. This was problematic when a URI-M specific a
URI-R with a port number, which was uncommon but exhibited with
captures from @phonedude's from a long time ago. Changed to
use the URL construct built into JS and created a function to
check this and return on exception, which indicates not a valid
URI.

Closes #289